### PR TITLE
Update bp_object.py

### DIFF
--- a/ops/bp_object.py
+++ b/ops/bp_object.py
@@ -166,6 +166,7 @@ class bp_object_OT_add_camera(bpy.types.Operator):
     def execute(self, context):
         bpy.ops.object.camera_add(align='VIEW')
         camera = context.active_object
+        bpy.context.scene.camera = camera
         bpy.ops.view3d.camera_to_view()
         camera.data.clip_start = .01
         camera.data.clip_end = 9999


### PR DESCRIPTION
Previously new cameras would sit at world origin on creation and only the scene camera would be moved

Setting the newly created camera as the scene cam fixes this